### PR TITLE
Fix compatibility with Ruby 2.0

### DIFF
--- a/lib/backwards.rb
+++ b/lib/backwards.rb
@@ -9,7 +9,7 @@ if Minitest::Versions::MAJOR <= 4
 end
 
 # Y U NO Ruby 2.0????
-unless Kernel.public_method_defined? :__dir__
+unless Kernel.respond_to?(:__dir__, false)
   module Kernel
     def __dir__
       File.dirname(File.expand_path(__FILE__))


### PR DESCRIPTION
`public_method_defined?` was not behaving like expected with Ruby 2.2
and was breaking `__dir__`