### PR TITLE
add default test description

### DIFF
--- a/lib/minispec-metadata/it.rb
+++ b/lib/minispec-metadata/it.rb
@@ -7,7 +7,7 @@ module MinispecMetadata
 
     module ClassMethods
 
-      def it(description, *metadata, &block)
+      def it(description = 'anonymous', *metadata, &block)
         name = super description, &block
 
         metadata = MinispecMetadata.extract_metadata(metadata)


### PR DESCRIPTION
To be coherent with minitest gem and accept `it` without description arguments:
https://github.com/seattlerb/minitest/blob/master/lib/minitest/spec.rb#L216