### PR TITLE
Non-DSL Metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: ruby
 rvm:
   - 2.0.0
-  - 2.1.2
-  - 2.2.2
-  - 2.4.1
+  - 2.1.10
+  - 2.2.10
+  - 2.4.7
+  - 2.5.6
+  - 2.6.4
 
 script: bundle exec rake
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ describe 'VCR trick' do
 end
 ```
 
-Metadata can also be used without the spec DSL when extending `Minitest::Test` by requiring `minispec-metadata/test`.
+Metadata can also be used without the spec DSL when extending `Minitest::Test`, or `Minitest::Unit::TestCase` for
+Minitest 4, by requiring `minispec-metadata/test`.
 
 ```ruby
 # readme.test.spec.rb

--- a/README.md
+++ b/README.md
@@ -82,6 +82,33 @@ describe 'VCR trick' do
 end
 ```
 
+Metadata can also be used without the spec DSL when extending `Minitest::Test` by requiring `minispec-metadata/test`.
+
+```ruby
+# readme.test.spec.rb
+require 'minitest/autorun'
+require 'minispec-metadata'
+require 'minispec-metadata/test'
+
+class MyTestClass < Minitest::Test
+  meta_all :foo => :bar # Metadata that will be applied to all tests
+
+  meta :slow # Metadata will be applied to the next available test.
+  def test_metadata_has_meta_from_class_and_test
+    assert_equal metadata, { :foo => :bar, :slow => true }
+  end
+
+  meta :not_used
+  def some_helper_method
+    assert_equal metadata, :foo => :bar
+  end
+
+  def test_metadata_does_not_leak
+    assert_equal metadata, :foo => :bar
+  end
+end
+```
+
 ### Tags
 
 (Only for Ruby >= 2 and Minitest >= 5)

--- a/lib/minispec-metadata/test.rb
+++ b/lib/minispec-metadata/test.rb
@@ -12,7 +12,7 @@ module MinispecMetadata
       end
 
       def last_defined_metadata
-        @last_defined_metadata || {}
+        @last_defined_metadata ||= {}
       end
 
       def last_defined_metadata=(value)

--- a/lib/minispec-metadata/test.rb
+++ b/lib/minispec-metadata/test.rb
@@ -1,0 +1,58 @@
+require 'minitest/test'
+
+module MinispecMetadata
+  module Test
+    def self.included(test_class)
+      test_class.extend ClassMethods
+    end
+
+    module ClassMethods
+      def meta(*metadata)
+        self.last_defined_metadata = MinispecMetadata.extract_metadata(metadata)
+      end
+
+      def last_defined_metadata
+        @last_defined_metadata || {}
+      end
+
+      def last_defined_metadata=(value)
+        @last_defined_metadata = value
+      end
+
+      def metadata_by_test_name
+        @metadata_by_test_name ||= {}
+      end
+
+      def method_added(method_name)
+        method_name = method_name.to_s
+        if method_name.start_with?("test_")
+          metadata_by_test_name[method_name] = last_defined_metadata
+        end
+
+        self.last_defined_metadata = nil
+      end
+
+      def meta_all(*metadata)
+        new_metadata = MinispecMetadata.extract_metadata(metadata)
+        warn "Overwriting test metadata for #{self}: #{@metadata_for_all_tests} => #{new_metadata}" unless metadata_for_all_tests.empty?
+        @metadata_for_all_tests = new_metadata
+      end
+
+      def metadata_for_all_tests
+        @metadata_for_all_tests || {}
+      end
+
+      def metadata_for_test_name(test_name)
+        metadata_for_all_tests.merge(
+          metadata_by_test_name.fetch(test_name)
+        )
+      end
+    end
+
+    def metadata
+      self.class.metadata_for_test_name(name)
+    end
+  end
+end
+
+Minitest::Test.send :include, MinispecMetadata::Test

--- a/lib/minispec-metadata/test.rb
+++ b/lib/minispec-metadata/test.rb
@@ -1,4 +1,8 @@
-require 'minitest/test'
+if Minitest::Versions::MAJOR >= 5
+  require 'minitest/test'
+else
+  require 'minitest/unit'
+end
 
 module MinispecMetadata
   module Test
@@ -39,7 +43,7 @@ module MinispecMetadata
       end
 
       def metadata_for_all_tests
-        @metadata_for_all_tests || {}
+        @metadata_for_all_tests ||= {}
       end
 
       def metadata_for_test_name(test_name)
@@ -55,4 +59,8 @@ module MinispecMetadata
   end
 end
 
-Minitest::Test.send :include, MinispecMetadata::Test
+if Minitest::Versions::MAJOR >= 5
+  Minitest::Test.send :include, MinispecMetadata::Test
+else
+  Minitest::Unit::TestCase.send :include, MinispecMetadata::Test
+end

--- a/spec/readme.test.spec.rb
+++ b/spec/readme.test.spec.rb
@@ -1,9 +1,11 @@
 require_relative 'helper'
 
-readme = File.readlines(File.dirname(__FILE__) + '/../README.md').map(&:chomp)
-tests =
-  readme.select do |line, idx|
-    true if (line == '# readme.test.spec.rb')..(line == '```')
-  end[0...-1]
-  .join("\n")
-instance_eval tests
+if Minitest::Versions::MAJOR >= 5
+  readme = File.readlines(File.dirname(__FILE__) + '/../README.md').map(&:chomp)
+  tests =
+    readme.select do |line, idx|
+      true if (line == '# readme.test.spec.rb')..(line == '```')
+    end[0...-1]
+      .join("\n")
+    instance_eval tests
+end

--- a/spec/readme.test.spec.rb
+++ b/spec/readme.test.spec.rb
@@ -1,0 +1,9 @@
+require_relative 'helper'
+
+readme = File.readlines(File.dirname(__FILE__) + '/../README.md').map(&:chomp)
+tests =
+  readme.select do |line, idx|
+    true if (line == '# readme.test.spec.rb')..(line == '```')
+  end[0...-1]
+  .join("\n")
+instance_eval tests

--- a/spec/test.spec.rb
+++ b/spec/test.spec.rb
@@ -1,7 +1,9 @@
 require_relative 'helper'
 require 'minispec-metadata/test'
 
-class TestMetaSpec < Minitest::Test
+base_klass = Minitest::Versions::MAJOR >= 5 ? Minitest::Test : Minitest::Unit::TestCase
+
+class TestMetaSpec < base_klass
   meta foo: :bar
   def test_metadata_returns_set_metadata
     metadata.fetch(:foo).must_equal :bar
@@ -22,7 +24,7 @@ class TestMetaSpec < Minitest::Test
   end
 end
 
-class TestAllMetaSpec < Minitest::Test
+class TestAllMetaSpec < base_klass
   meta_all :all
 
   meta :one
@@ -38,7 +40,7 @@ class TestAllMetaSpec < Minitest::Test
   end
 end
 
-class TestLifecycleSpec < Minitest::Test
+class TestLifecycleSpec < base_klass
   def setup
     assert_equal metadata.fetch(:setup), 'accessible'
   end

--- a/spec/test.spec.rb
+++ b/spec/test.spec.rb
@@ -40,7 +40,7 @@ end
 
 class TestLifecycleSpec < Minitest::Test
   def setup
-    metadata.fetch(:setup).must_equal 'accessible'
+    assert_equal metadata.fetch(:setup), 'accessible'
   end
 
   meta setup: 'accessible', teardown: 'also accessible'
@@ -49,6 +49,6 @@ class TestLifecycleSpec < Minitest::Test
   end
 
   def teardown
-    metadata.fetch(:teardown).must_equal 'also accessible'
+    assert_equal metadata.fetch(:teardown), 'also accessible'
   end
 end

--- a/spec/test.spec.rb
+++ b/spec/test.spec.rb
@@ -6,21 +6,21 @@ base_klass = Minitest::Versions::MAJOR >= 5 ? Minitest::Test : Minitest::Unit::T
 class TestMetaSpec < base_klass
   meta foo: :bar
   def test_metadata_returns_set_metadata
-    metadata.fetch(:foo).must_equal :bar
+    assert_equal metadata.fetch(:foo), :bar
   end
 
   def test_metadata_returns_empty_hash_when_no_metadata_set
-    metadata.must_equal({})
+    assert_equal metadata, {}
   end
 
   meta :not_used
   def some_helper_method
-    metadata.keys.wont_include :not_used
+    refute_includes metadata.keys, :not_used
   end
 
   def test_metadata_only_applies_to_test_methods
     some_helper_method
-    metadata.keys.wont_include :not_used
+    refute_includes metadata.keys, :not_used
   end
 end
 
@@ -29,14 +29,14 @@ class TestAllMetaSpec < base_klass
 
   meta :one
   def test_metadata_returns_meta_for_all_file_one
-    metadata.fetch(:all).must_equal true
-    metadata.fetch(:one).must_equal true
+    assert_equal metadata.fetch(:all), true
+    assert_equal metadata.fetch(:one), true
   end
 
   meta :two
   def test_metadata_returns_meta_for_all_file_two
-    metadata.fetch(:all).must_equal true
-    metadata.fetch(:two).must_equal true
+    assert_equal metadata.fetch(:all), true
+    assert_equal metadata.fetch(:two), true
   end
 end
 

--- a/spec/test.spec.rb
+++ b/spec/test.spec.rb
@@ -1,0 +1,54 @@
+require_relative 'helper'
+require 'minispec-metadata/test'
+
+class TestMetaSpec < Minitest::Test
+  meta foo: :bar
+  def test_metadata_returns_set_metadata
+    metadata.fetch(:foo).must_equal :bar
+  end
+
+  def test_metadata_returns_empty_hash_when_no_metadata_set
+    metadata.must_equal({})
+  end
+
+  meta :not_used
+  def some_helper_method
+    metadata.keys.wont_include :not_used
+  end
+
+  def test_metadata_only_applies_to_test_methods
+    some_helper_method
+    metadata.keys.wont_include :not_used
+  end
+end
+
+class TestAllMetaSpec < Minitest::Test
+  meta_all :all
+
+  meta :one
+  def test_metadata_returns_meta_for_all_file_one
+    metadata.fetch(:all).must_equal true
+    metadata.fetch(:one).must_equal true
+  end
+
+  meta :two
+  def test_metadata_returns_meta_for_all_file_two
+    metadata.fetch(:all).must_equal true
+    metadata.fetch(:two).must_equal true
+  end
+end
+
+class TestLifecycleSpec < Minitest::Test
+  def setup
+    metadata.fetch(:setup).must_equal 'accessible'
+  end
+
+  meta setup: 'accessible', teardown: 'also accessible'
+  def test_metadata_is_accessible_in_hooks
+    pass
+  end
+
+  def teardown
+    metadata.fetch(:teardown).must_equal 'also accessible'
+  end
+end


### PR DESCRIPTION
This allows metadata to be used when extending `Minitest::Test` as opposed to the spec DSL. Metadata can be added with the `meta` method much like `desc` is used in rake for giving a description for tasks.

I'm not married to the `meta`/`meta_all` method names. Maybe `tag`/`tag_all` would be better?