### PR TITLE
use Minitest instead of MiniTest

### DIFF
--- a/lib/minitest/versions.rb
+++ b/lib/minitest/versions.rb
@@ -1,9 +1,5 @@
 module Minitest
-
   module Versions
-
-    MAJOR, MINOR, PATCH = Minitest::Unit::VERSION.split('.').map(&:to_i)
-
+    MAJOR, MINOR, PATCH = Minitest::VERSION.split('.').map(&:to_i)
   end
-
 end

--- a/minispec-metadata.gemspec
+++ b/minispec-metadata.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |gem|
   gem.version       = MinispecMetadata::VERSION
   gem.authors       = ["Jared Ning"]
   gem.email         = ["jared@redningja.com"]
-  gem.description   = %q{MiniTest::Spec metadata}
-  gem.summary       = %q{Pass metadata to MiniTest::Spec descriptions and specs like in RSpec.}
+  gem.description   = %q{Minitest::Spec metadata}
+  gem.summary       = %q{Pass metadata to Minitest::Spec descriptions and specs like in RSpec.}
   gem.homepage      = "https://github.com/ordinaryzelig/minispec-metadata"
   gem.license       = 'MIT'
 

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -5,6 +5,6 @@ require 'minitest/autorun'
 require 'minitest/pride'
 require 'minispec-metadata'
 
-class MiniTest::Unit::TestCase
+class Minitest::Unit::TestCase
   parallelize_me!
 end


### PR DESCRIPTION
the rename happened in 5.0, but 5.19.0 started to only define the old alias when `ENV["MT_COMPAT"]` is defined, which usually is not the case